### PR TITLE
Address prefixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,6 @@ service-market-environment-location-product
 | Name | Version |
 |------|---------|
 | azurerm | >= 2.0.0 |
-| http | >= 1.2.0 |
 
 ## Inputs
 
@@ -25,8 +24,9 @@ service-market-environment-location-product
 | location | Azure Region | `string` | n/a | yes |
 | names | Names to be applied to resources | `map(string)` | n/a | yes |
 | naming\_conventions\_yaml\_url | URL for naming conventions yaml file | `string` | `"https://raw.githubusercontent.com/openrba/python-azure-naming/master/custom.yaml"` | no |
+| naming\_rules | n/a | `string` | n/a | yes |
 | resource\_group\_name | Resource group name | `string` | n/a | yes |
-| subnets | Subnet types and CIDRs. format: { [0-9][0-9]-<subnet\_type> = cidr }) (increment from 01, cannot be reordered) | `map(string)` | `{}` | no |
+| subnets | Subnet types and lists of CIDRs. format: { [0-9][0-9]-<subnet\_type> = cidr }) (increment from 01, cannot be reordered) | `map(list(string))` | `{}` | no |
 | tags | Tags to be applied to resources | `map(string)` | n/a | yes |
 
 ## Outputs

--- a/data_sources.tf
+++ b/data_sources.tf
@@ -1,13 +1,5 @@
-data "http" "naming_rules" {
-  url = var.naming_conventions_yaml_url
-
-  request_headers = {
-    Accept = "application/yaml"
-  }
-}
-
 locals {
-  naming_rules = yamldecode(data.http.naming_rules.body)
+  naming_rules = yamldecode(var.naming_rules)
   subnet_types = local.naming_rules.subnetType.allowed_values
 
   valid_subnet_input = [

--- a/main.tf
+++ b/main.tf
@@ -11,7 +11,8 @@ resource "azurerm_subnet" "subnet" {
   name                 = "${substr(keys(var.subnets)[count.index], 3, -1)}-subnet"
   resource_group_name  = var.resource_group_name
   virtual_network_name = azurerm_virtual_network.vnet.name
-  address_prefix       = values(var.subnets)[count.index]
+  #address_prefixes     = [values(var.subnets)[count.index]]
+  address_prefixes     = values(var.subnets)[count.index]
 }
 
 resource "azurerm_subnet_network_security_group_association" "subnet_nsg" {

--- a/variables.tf
+++ b/variables.tf
@@ -4,6 +4,10 @@ variable "naming_conventions_yaml_url" {
   default     = "https://raw.githubusercontent.com/openrba/python-azure-naming/master/custom.yaml" 
 }
 
+variable "naming_rules" {
+  type = string
+}
+
 variable "resource_group_name"{
   description = "Resource group name"
   type        = string
@@ -32,6 +36,6 @@ variable "address_space"{
 
 variable "subnets" {
   description = "Subnet types and lists of CIDRs. format: { [0-9][0-9]-<subnet_type> = cidr }) (increment from 01, cannot be reordered)"
-  #type        = map(list)
-  #default     = {}
+  type        = map(list(string))
+  default     = {}
 }

--- a/variables.tf
+++ b/variables.tf
@@ -31,7 +31,7 @@ variable "address_space"{
 }
 
 variable "subnets" {
-  description = "Subnet types and CIDRs. format: { [0-9][0-9]-<subnet_type> = cidr }) (increment from 01, cannot be reordered)"
-  type        = map(string)
-  default     = {}
+  description = "Subnet types and lists of CIDRs. format: { [0-9][0-9]-<subnet_type> = cidr }) (increment from 01, cannot be reordered)"
+  #type        = map(list)
+  #default     = {}
 }


### PR DESCRIPTION
the address_prefix parameter has been deprecated in favor of address_prefixes.  The input variable for subnets is changed from a map(string) to a map(list(string)) to accommodate using multiple CIDR ranges in the same subnet.