### PR TITLE
Output the name of vnet

### DIFF
--- a/output.tf
+++ b/output.tf
@@ -3,6 +3,11 @@ output "vnet" {
   value        = azurerm_virtual_network.vnet
 }
 
+output "vnet_name" {
+  description  = "Virtual network resource"
+  value        = azurerm_virtual_network.vnet.name
+}
+
 output "subnet" {
   description = "Map of subnet resources"
   value       = zipmap(


### PR DESCRIPTION
Output the name of vnet so that it can be used elsewhere, for example, in creating vnet peering.