### PR TITLE
Optional validation

### DIFF
--- a/example/custom_routes/main.tf
+++ b/example/custom_routes/main.tf
@@ -82,7 +82,9 @@ module "virtual_network" {
                         allow_vnet_outbound     = true
                         route_table_association = "default"
                       }
+   "foo" = { cidrs = ["10.1.3.0/24"] }
   }
+  enforce_subnet_names = false
 
   route_tables = {
     default = {
@@ -114,5 +116,4 @@ module "virtual_network" {
       }
     }
   }
-
 }

--- a/example/custom_routes/main.tf
+++ b/example/custom_routes/main.tf
@@ -82,9 +82,7 @@ module "virtual_network" {
                         allow_vnet_outbound     = true
                         route_table_association = "default"
                       }
-   "foo" = { cidrs = ["10.1.3.0/24"] }
   }
-  enforce_subnet_names = false
 
   route_tables = {
     default = {

--- a/example/custom_routes/test.tf
+++ b/example/custom_routes/test.tf
@@ -1,13 +1,3 @@
-data "azurerm_subnet" "subnet" {
-  for_each = module.virtual_network.subnets	
-
-  name                 = each.value.name
-  virtual_network_name = each.value.virtual_network_name
-  resource_group_name  = each.value.resource_group_name
-}
-
-output "foo" {
-  #value = (lookup(data.azurerm_subnet.subnet["iaas-public"], "route_table_id", null) != null ? "foo" : "bar")
-  #value = data.azurerm_subnet.subnet["iaas-public"].route_table_id
-  value = (data.azurerm_subnet.subnet["iaas-outbound"].route_table_id == "" ? "foo" : "bar")
+output "subnets" {
+  value = module.virtual_network.subnets
 }

--- a/locals.tf
+++ b/locals.tf
@@ -1,12 +1,4 @@
 locals {
-  naming_rules = yamldecode(var.naming_rules)
-  subnet_types = local.naming_rules.subnetType.allowed_values
-
-  valid_subnet_type = [
-    for subnet in keys(var.subnets):
-    (contains(keys(local.subnet_types), subnet) ? null : file("ERROR: invalid input value for reserved subnet type"))
-  ]
-
   subnets = zipmap(keys(var.subnets), [ for subnet in values(var.subnets): merge(var.subnet_defaults, subnet) ])
 
   route_table_associations = {for i, z in local.subnets: i => z.route_table_association if z.route_table_association != null}

--- a/locals.tf
+++ b/locals.tf
@@ -1,4 +1,6 @@
 locals {
+  enforce_subnet_names = (var.naming_rules == "" ? false : var.enforce_subnet_names)
+
   subnets = zipmap(keys(var.subnets), [ for subnet in values(var.subnets): merge(var.subnet_defaults, subnet) ])
 
   route_table_associations = {for i, z in local.subnets: i => z.route_table_association if z.route_table_association != null}

--- a/main.tf
+++ b/main.tf
@@ -15,7 +15,8 @@ module "subnet" {
   location            = var.location
   tags                = var.tags
 
-  naming_rules        = (var.enforce_subnet_names ? var.naming_rules : "")
+  naming_rules         = var.naming_rules
+  enforce_subnet_names = var.enforce_subnet_names
 
   virtual_network_name = azurerm_virtual_network.vnet.name
   subnet_type          = each.key

--- a/main.tf
+++ b/main.tf
@@ -10,11 +10,12 @@ module "subnet" {
   source   = "./subnet"
   for_each = local.subnets
 
-  naming_rules        = var.naming_rules
+  names               = var.names
   resource_group_name = var.resource_group_name
   location            = var.location
-  names               = var.names
   tags                = var.tags
+
+  naming_rules        = (var.enforce_subnet_names ? var.naming_rules : "")
 
   virtual_network_name = azurerm_virtual_network.vnet.name
   subnet_type          = each.key

--- a/main.tf
+++ b/main.tf
@@ -16,7 +16,7 @@ module "subnet" {
   tags                = var.tags
 
   naming_rules         = var.naming_rules
-  enforce_subnet_names = var.enforce_subnet_names
+  enforce_subnet_names = local.enforce_subnet_names
 
   virtual_network_name = azurerm_virtual_network.vnet.name
   subnet_type          = each.key

--- a/subnet/data_sources.tf
+++ b/subnet/data_sources.tf
@@ -1,6 +1,0 @@
-locals {
-  naming_rules = yamldecode(var.naming_rules)
-  subnet_types = local.naming_rules.subnetType.allowed_values
-
-  valid_subnet_type = (contains(keys(local.subnet_types), var.subnet_type) ? null : file("ERROR: invalid input value for reserved subnet type"))
-}

--- a/subnet/locals.tf
+++ b/subnet/locals.tf
@@ -1,7 +1,7 @@
 locals {
-  naming_rules = yamldecode(var.naming_rules)
+  naming_rules = (var.naming_rules != "" ? yamldecode(var.naming_rules) : null) 
 
-  allowed_subnet_info = local.naming_rules.subnetType.allowed_values
+  allowed_subnet_info = (local.naming_rules != null ? local.naming_rules.subnetType.allowed_values : {})
 
   valid_subnet_type = (var.enforce_subnet_names ? (contains(keys(local.allowed_subnet_info), var.subnet_type) ?
                        null : file("ERROR: invalid input value for reserved subnet type")) : null)

--- a/subnet/locals.tf
+++ b/subnet/locals.tf
@@ -1,0 +1,8 @@
+locals {
+  naming_rules = (var.naming_rules != "" ? yamldecode(var.naming_rules) : null)
+
+  subnet_types = (local.naming_rules != null ? local.naming_rules.subnetType.allowed_values : null)
+
+  valid_subnet_type = (local.naming_rules != null ? (contains(keys(local.subnet_types), var.subnet_type) ?
+                       null : file("ERROR: invalid input value for reserved subnet type")) : null)
+}

--- a/subnet/locals.tf
+++ b/subnet/locals.tf
@@ -1,8 +1,8 @@
 locals {
-  naming_rules = (var.naming_rules != "" ? yamldecode(var.naming_rules) : null)
+  naming_rules = yamldecode(var.naming_rules)
 
-  subnet_types = (local.naming_rules != null ? local.naming_rules.subnetType.allowed_values : null)
+  allowed_subnet_info = local.naming_rules.subnetType.allowed_values
 
-  valid_subnet_type = (local.naming_rules != null ? (contains(keys(local.subnet_types), var.subnet_type) ?
+  valid_subnet_type = (var.enforce_subnet_names ? (contains(keys(local.allowed_subnet_info), var.subnet_type) ?
                        null : file("ERROR: invalid input value for reserved subnet type")) : null)
 }

--- a/subnet/main.tf
+++ b/subnet/main.tf
@@ -30,8 +30,7 @@ resource "azurerm_network_security_group" "nsg" {
   name                = "${var.names.resource_group_type}-${var.names.product_name}-${var.subnet_type}-security-group"
   location            = var.location
   resource_group_name = var.resource_group_name
-  tags                = merge(var.tags, {subnet_type = (local.subnet_types != null ?
-                              lookup(local.subnet_types, var.subnet_type) : var.subnet_type)})
+  tags                = merge(var.tags, {subnet_type = lookup(local.allowed_subnet_info, var.subnet_type, var.subnet_type)})
 }
 
 resource "azurerm_network_security_rule" "deny_all_inbound" {

--- a/subnet/main.tf
+++ b/subnet/main.tf
@@ -30,7 +30,8 @@ resource "azurerm_network_security_group" "nsg" {
   name                = "${var.names.resource_group_type}-${var.names.product_name}-${var.subnet_type}-security-group"
   location            = var.location
   resource_group_name = var.resource_group_name
-  tags                = merge(var.tags, {subnet_type = lookup(local.subnet_types,var.subnet_type)})
+  tags                = merge(var.tags, {subnet_type = (local.subnet_types != null ?
+                              lookup(local.subnet_types, var.subnet_type) : var.subnet_type)})
 }
 
 resource "azurerm_network_security_rule" "deny_all_inbound" {

--- a/subnet/variables.tf
+++ b/subnet/variables.tf
@@ -1,8 +1,3 @@
-variable "naming_rules" {
-  description = "naming conventions yaml file"
-  type        = string
-}
-
 variable "resource_group_name"{
   description = "Resource group name"
   type        = string
@@ -21,6 +16,12 @@ variable "names" {
 variable "tags" {
   description = "tags to be applied to resources"
   type        = map(string)
+}
+
+variable "naming_rules" {
+  description = "naming conventions yaml file"
+  type        = string
+  default     = ""
 }
 
 # Networking

--- a/subnet/variables.tf
+++ b/subnet/variables.tf
@@ -24,6 +24,12 @@ variable "naming_rules" {
   default     = ""
 }
 
+variable "enforce_subnet_names" {
+  description = "enforce subnet naming rules"
+  type        = bool
+}
+  
+
 # Networking
 variable "virtual_network_name" {
   description = "virtual network name"

--- a/variables.tf
+++ b/variables.tf
@@ -21,6 +21,7 @@ variable "tags" {
 variable "naming_rules" {
   description = "naming conventions yaml file" 
   type        = string
+  default     = ""
 }
 
 variable "enforce_subnet_names" {

--- a/variables.tf
+++ b/variables.tf
@@ -1,8 +1,3 @@
-variable "naming_rules" {
-  description = "naming conventions yaml file" 
-  type        = string
-}
-
 variable "resource_group_name"{
   description = "Resource group name"
   type        = string
@@ -21,6 +16,17 @@ variable "names" {
 variable "tags" {
   description = "Tags to be applied to resources"
   type        = map(string)
+}
+
+variable "naming_rules" {
+  description = "naming conventions yaml file" 
+  type        = string
+}
+
+variable "enforce_subnet_names" {
+  description = "enforce subnet names based on naming_rules variable"
+  type        = bool
+  default     = true
 }
 
 # Networking


### PR DESCRIPTION
There was a desire to allow more free-form subnet names for certain scenarios.
Naming rules input is no longer required, but if used, friendly tags will be used for any matching subnet types.