### PR TITLE
make nsg rules optional

### DIFF
--- a/example/bastion/main.tf
+++ b/example/bastion/main.tf
@@ -91,14 +91,14 @@ module "virtual_network" {
   address_space = ["10.1.0.0/22"]
 
   subnets = {
-    "iaas-public"   = { cidrs                    = ["10.1.0.0/24"]
-                        allow_vnet_inbound       = true
-                        allow_vnet_outbound      = true
-                      }
-    "iaas-private"   = { cidrs                   = ["10.1.1.0/24"]
-                        allow_vnet_inbound       = true
-                        allow_vnet_outbound      = true
-                      }
+    "iaas-public"  = { cidrs                    = ["10.1.0.0/24"]
+                       allow_vnet_inbound       = true
+                       allow_vnet_outbound      = true
+                     }
+    "iaas-private" = { cidrs                   = ["10.1.1.0/24"]
+                       allow_vnet_inbound       = true
+                       allow_vnet_outbound      = true
+                     }
   }
 }
 

--- a/main.tf
+++ b/main.tf
@@ -26,6 +26,7 @@ module "subnet" {
   service_endpoints = each.value.service_endpoints
   delegations       = each.value.delegations
 
+  configure_nsg_rules     = each.value.configure_nsg_rules
   allow_internet_outbound = each.value.allow_internet_outbound
   allow_lb_inbound        = each.value.allow_lb_inbound
   allow_vnet_inbound      = each.value.allow_vnet_inbound

--- a/subnet/main.tf
+++ b/subnet/main.tf
@@ -34,6 +34,7 @@ resource "azurerm_network_security_group" "nsg" {
 }
 
 resource "azurerm_network_security_rule" "deny_all_inbound" {
+  count                       = (var.configure_nsg_rules ? 1 : 0)
   name                        = "DenyAllInbound"
   priority                    = 4096
   direction                   = "Inbound"
@@ -48,6 +49,7 @@ resource "azurerm_network_security_rule" "deny_all_inbound" {
 }
 
 resource "azurerm_network_security_rule" "deny_all_outbound" {
+  count                       = (var.configure_nsg_rules ? 1 : 0)
   name                        = "DenyAllOutbound"
   priority                    = 4096
   direction                   = "Outbound"
@@ -62,7 +64,7 @@ resource "azurerm_network_security_rule" "deny_all_outbound" {
 }
 
 resource "azurerm_network_security_rule" "allow_lb_inbound" {
-  count                       = (var.allow_lb_inbound ? 1 : 0)
+  count                       = (var.configure_nsg_rules && var.allow_lb_inbound ? 1 : 0)
   name                        = "AllowAzureLoadBalancerIn"
   priority                    = 4095
   direction                   = "Inbound"
@@ -77,7 +79,7 @@ resource "azurerm_network_security_rule" "allow_lb_inbound" {
 }
 
 resource "azurerm_network_security_rule" "allow_internet_outbound" {
-  count                       = (var.allow_internet_outbound ? 1 : 0)
+  count                       = (var.configure_nsg_rules && var.allow_internet_outbound ? 1 : 0)
   name                        = "AllowInternetOut"
   priority                    = 4095
   direction                   = "Outbound"
@@ -92,7 +94,7 @@ resource "azurerm_network_security_rule" "allow_internet_outbound" {
 }
 
 resource "azurerm_network_security_rule" "allow_vnet_inbound" {
-  count                       = (var.allow_vnet_inbound ? 1 : 0)
+  count                       = (var.configure_nsg_rules && var.allow_vnet_inbound ? 1 : 0)
   name                        = "AllowVnetIn"
   priority                    = 4094
   direction                   = "Inbound"
@@ -107,7 +109,7 @@ resource "azurerm_network_security_rule" "allow_vnet_inbound" {
 }
 
 resource "azurerm_network_security_rule" "allow_vnet_outbound" {
-  count                       = (var.allow_vnet_outbound ? 1 : 0)
+  count                       = (var.configure_nsg_rules && var.allow_vnet_outbound ? 1 : 0)
   name                        = "AllowVnetOut"
   priority                    = 4094
   direction                   = "Outbound"

--- a/subnet/variables.tf
+++ b/subnet/variables.tf
@@ -39,6 +39,11 @@ variable "cidrs" {
   type        = list(string)
 }
 
+variable "configure_nsg_rules" {
+  description = "Configure network security group rules"
+  type        = bool
+}
+
 variable "allow_internet_outbound" {
   description = "allow outbound traffic to internet"
   type        = bool

--- a/variables.tf
+++ b/variables.tf
@@ -33,6 +33,16 @@ variable "subnets" {
   description = "Map of subnets. Keys are subnet names, Allowed values are the same as for subnet_defaults."
   type        = any
   default     = {}
+
+  validation {
+    condition     = (length(compact([for subnet in var.subnets: (!lookup(subnet, "configure_nsg_rules", false) &&
+                     (contains(keys(subnet), "allow_internet_outbound") ||
+                     contains(keys(subnet), "allow_lb_inbound") ||
+                     contains(keys(subnet), "allow_vnet_inbound") ||
+                     contains(keys(subnet), "allow_vnet_outbound")) ?
+                     "invalid" : "")])) == 0)
+    error_message = "Subnet rules only allowed when configure_nsg_rules is set to \"true\"."
+  }
 }
 
 variable "subnet_defaults" {

--- a/variables.tf
+++ b/variables.tf
@@ -57,10 +57,10 @@ variable "subnet_defaults" {
                                                                           actions = list(string)
                                                                        }))
                   configure_nsg_rules                            = bool   # deny ingress/egress traffic and configure nsg rules based on below parameters
-                  allow_internet_outbound                        = bool   # allow outbound traffic to internet
-                  allow_lb_inbound                               = bool   # allow inbound traffic from Azure Load Balancer
-                  allow_vnet_inbound                             = bool   # allow all inbound from virtual network
-                  allow_vnet_outbound                            = bool   # allow all outbound from virtual network
+                  allow_internet_outbound                        = bool   # allow outbound traffic to internet (configure_nsg_rules must be set to true)
+                  allow_lb_inbound                               = bool   # allow inbound traffic from Azure Load Balancer (configure_nsg_rules must be set to true)
+                  allow_vnet_inbound                             = bool   # allow all inbound from virtual network (configure_nsg_rules must be set to true)
+                  allow_vnet_outbound                            = bool   # allow all outbound from virtual network (configure_nsg_rules must be set to true)
                   route_table_association                        = string
                 })
   default     = { 

--- a/variables.tf
+++ b/variables.tf
@@ -35,13 +35,13 @@ variable "subnets" {
   default     = {}
 
   validation {
-    condition     = (length(compact([for subnet in var.subnets: (!lookup(subnet, "configure_nsg_rules", false) &&
+    condition     = (length(compact([for subnet in var.subnets: (!lookup(subnet, "configure_nsg_rules", true) &&
                      (contains(keys(subnet), "allow_internet_outbound") ||
                      contains(keys(subnet), "allow_lb_inbound") ||
                      contains(keys(subnet), "allow_vnet_inbound") ||
                      contains(keys(subnet), "allow_vnet_outbound")) ?
                      "invalid" : "")])) == 0)
-    error_message = "Subnet rules only allowed when configure_nsg_rules is set to \"true\"."
+    error_message = "Subnet rules not allowed when configure_nsg_rules is set to \"false\"."
   }
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -46,6 +46,7 @@ variable "subnet_defaults" {
                                                                           name    = string
                                                                           actions = list(string)
                                                                        }))
+                  configure_nsg_rules                            = bool   # deny ingress/egress traffic and configure nsg rules based on below parameters
                   allow_internet_outbound                        = bool   # allow outbound traffic to internet
                   allow_lb_inbound                               = bool   # allow inbound traffic from Azure Load Balancer
                   allow_vnet_inbound                             = bool   # allow all inbound from virtual network
@@ -58,6 +59,7 @@ variable "subnet_defaults" {
                   enforce_private_link_service_network_policies  = false
                   service_endpoints                              = []
                   delegations                                    = {}
+                  configure_nsg_rules                            = true
                   allow_internet_outbound                        = false
                   allow_lb_inbound                               = false
                   allow_vnet_inbound                             = false
@@ -100,4 +102,3 @@ variable "peer_defaults" {
                   use_remote_gateways          = false   # https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/virtual_network_peering#use_remote_gateways
                 }
 }
-


### PR DESCRIPTION
There are certain subnets on Azure (Application Gateway, Redis, etc.) that require specific nsg rules that may conflict with the default deny rules that were being applied.  This makes those NSG rulesets optional.