### PR TITLE
Remove unused http provider and update dependencies syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,6 @@ service-market-environment-location-product
 |------|---------|
 | terraform | >= 0.13.0 |
 | azurerm | >= 2.0.0 |
-| http | >= 1.2.0 |
 
 ## Providers
 

--- a/versions.tf
+++ b/versions.tf
@@ -3,6 +3,5 @@ terraform {
 
   required_providers {
     azurerm = ">= 2.0.0"
-    http    = ">= 1.2.0"
   }
 }

--- a/versions.tf
+++ b/versions.tf
@@ -2,6 +2,9 @@ terraform {
   required_version = ">= 0.13.0"
 
   required_providers {
-    azurerm = ">= 2.0.0"
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = ">= 2.0.0"
+    }
   }
 }


### PR DESCRIPTION
- The http provider isn't used by the module itself, it's only present in the examples. It doesn't belong in the dependencies.
- Updates the syntax of versions.tf to set the source of the azurerm provider