### PR TITLE
Consistent use of subnet private policy variables

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -23,8 +23,8 @@ module "subnet" {
   subnet_type          = each.key
   cidrs                = each.value.cidrs
 
-  private_endpoint_network_policies_enabled     = each.value.enforce_private_link_endpoint_network_policies
-  private_link_service_network_policies_enabled = each.value.enforce_private_link_service_network_policies
+  private_endpoint_network_policies_enabled     = each.value.private_endpoint_network_policies_enabled
+  private_link_service_network_policies_enabled = each.value.private_link_service_network_policies_enabled
 
   service_endpoints = each.value.service_endpoints
   delegations       = each.value.delegations
@@ -92,8 +92,8 @@ module "aks_subnet" {
   subnet_type          = each.key
   cidrs                = each.value.cidrs
 
-  private_endpoint_network_policies_enabled     = each.value.enforce_private_link_endpoint_network_policies
-  private_link_service_network_policies_enabled = each.value.enforce_private_link_service_network_policies
+  private_endpoint_network_policies_enabled     = each.value.private_endpoint_network_policies_enabled
+  private_link_service_network_policies_enabled = each.value.private_link_service_network_policies_enabled
 
   service_endpoints = each.value.service_endpoints
   delegations       = each.value.delegations

--- a/main.tf
+++ b/main.tf
@@ -23,8 +23,8 @@ module "subnet" {
   subnet_type          = each.key
   cidrs                = each.value.cidrs
 
-  enforce_private_link_endpoint_network_policies = each.value.enforce_private_link_endpoint_network_policies
-  enforce_private_link_service_network_policies  = each.value.enforce_private_link_service_network_policies
+  private_endpoint_network_policies_enabled     = each.value.enforce_private_link_endpoint_network_policies
+  private_link_service_network_policies_enabled = each.value.enforce_private_link_service_network_policies
 
   service_endpoints = each.value.service_endpoints
   delegations       = each.value.delegations
@@ -92,8 +92,8 @@ module "aks_subnet" {
   subnet_type          = each.key
   cidrs                = each.value.cidrs
 
-  enforce_private_link_endpoint_network_policies = each.value.enforce_private_link_endpoint_network_policies
-  enforce_private_link_service_network_policies  = each.value.enforce_private_link_service_network_policies
+  private_endpoint_network_policies_enabled     = each.value.enforce_private_link_endpoint_network_policies
+  private_link_service_network_policies_enabled = each.value.enforce_private_link_service_network_policies
 
   service_endpoints = each.value.service_endpoints
   delegations       = each.value.delegations

--- a/subnet/main.tf
+++ b/subnet/main.tf
@@ -4,8 +4,8 @@ resource "azurerm_subnet" "subnet" {
   virtual_network_name = var.virtual_network_name
   address_prefixes     = var.cidrs
 
-  private_endpoint_network_policies_enabled = var.enforce_private_link_endpoint_network_policies
-  private_link_service_network_policies_enabled  = var.enforce_private_link_service_network_policies
+  private_endpoint_network_policies_enabled = var.private_endpoint_network_policies_enabled
+  private_link_service_network_policies_enabled  = var.private_link_service_network_policies_enabled
 
   service_endpoints = var.service_endpoints
 

--- a/subnet/variables.tf
+++ b/subnet/variables.tf
@@ -83,16 +83,16 @@ variable "allow_vnet_outbound" {
 }
 
 # Subnet Options
-variable "enforce_private_link_endpoint_network_policies" {
-  description = "enable network policies for the private link endpoint on the subnet"
+variable "private_endpoint_network_policies_enabled" {
+  description = "Enable or Disable network policies for the private endpoint on the subnet. Setting this to true will Enable the policy and setting this to false will Disable the policy."
   type        = bool
-  default     = false
+  default     = true
 }
 
-variable "enforce_private_link_service_network_policies" {
-  description = "enable network policies for the private link service on the subnet"
+variable "private_link_service_network_policies_enabled" {
+  description = "Enable or Disable network policies for the private link service on the subnet. Setting this to true will Enable the policy and setting this to false will Disable the policy."
   type        = bool
-  default     = false
+  default     = true
 }
 
 variable "service_endpoints" {

--- a/variables.tf
+++ b/variables.tf
@@ -75,10 +75,10 @@ variable "aks_subnets" {
 variable "subnet_defaults" {
   description = "Maps of CIDRs, policies, endpoints and delegations"
   type = object({
-    cidrs                                          = list(string)
-    enforce_private_link_endpoint_network_policies = bool
-    enforce_private_link_service_network_policies  = bool
-    service_endpoints                              = list(string)
+    cidrs                                         = list(string)
+    private_endpoint_network_policies_enabled     = bool
+    private_link_service_network_policies_enabled = bool
+    service_endpoints                             = list(string)
     delegations = map(object({
       name    = string
       actions = list(string)
@@ -92,18 +92,18 @@ variable "subnet_defaults" {
     route_table_association       = string
   })
   default = {
-    cidrs                                          = []
-    enforce_private_link_endpoint_network_policies = false
-    enforce_private_link_service_network_policies  = false
-    service_endpoints                              = []
-    delegations                                    = {}
-    create_network_security_group                  = true
-    configure_nsg_rules                            = true
-    allow_internet_outbound                        = false
-    allow_lb_inbound                               = false
-    allow_vnet_inbound                             = false
-    allow_vnet_outbound                            = false
-    route_table_association                        = null
+    cidrs                                         = []
+    private_endpoint_network_policies_enabled     = true
+    private_link_service_network_policies_enabled = true
+    service_endpoints                             = []
+    delegations                                   = {}
+    create_network_security_group                 = true
+    configure_nsg_rules                           = true
+    allow_internet_outbound                       = false
+    allow_lb_inbound                              = false
+    allow_vnet_inbound                            = false
+    allow_vnet_outbound                           = false
+    route_table_association                       = null
   }
 }
 


### PR DESCRIPTION
## Breaking Change

**🚨 This is a breaking change and should coincide with a major version release! 🚨**

## Description

The default values for `private_endpoint_network_policies_enabled `and `private_link_service_network_policies_enabled` are flipped to align with the provider's default values. **Azure flipped the meaning of these arguments when they were renamed.** [Source](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/subnet#private_endpoint_network_policies_enabled)

The keys in this module's variables are also updated to reflect the new names and default values.

This change will conform this module's API with the azurerm provider.

### Related PRs

#51 