### PR TITLE
support custom naming for vnet and documentation workflow improvements

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -4,22 +4,22 @@ jobs:
   docs:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683   #v4
       with:
         ref: ${{ github.event.pull_request.head.ref }}
 
     - name: Module
-      uses: Dirrk/terraform-docs@v1.0.8
+      uses: terraform-docs/gh-actions@aeae0038ed47a547e0c0fca5c059d3335f48fb25 
       with:
-        tf_docs_working_dir: .
-        tf_docs_output_file: README.md
-        tf_docs_output_method: inject
-        tf_docs_git_push: 'true'
+        working_dir: .
+        output_file: README.md
+        output_method: inject
+        git_push: 'true'
 
     - name: Submodule
-      uses: Dirrk/terraform-docs@v1.0.8
+      uses: terraform-docs/gh-actions@aeae0038ed47a547e0c0fca5c059d3335f48fb25 
       with:
-        tf_docs_working_dir: ./subnet/
-        tf_docs_output_file: README.md
-        tf_docs_output_method: inject
-        tf_docs_git_push: 'true'
+        working_dir: ./subnet/
+        output_file: README.md
+        output_method: inject
+        git_push: 'true'

--- a/README.md
+++ b/README.md
@@ -61,3 +61,69 @@ For a full list of details provided in the output please view:<br />
 - Virtual Network (vnet) - https://www.terraform.io/docs/providers/azurerm/r/virtual_network.html<br />
 - Subnet(s) - https://www.terraform.io/docs/providers/azurerm/r/subnet.html<br />
 <br />
+<!-- BEGIN_TF_DOCS -->
+## Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.0 |
+| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | >= 3.18.0 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | >= 3.18.0 |
+
+## Modules
+
+| Name | Source | Version |
+|------|--------|---------|
+| <a name="module_aks_subnet"></a> [aks\_subnet](#module\_aks\_subnet) | ./subnet | n/a |
+| <a name="module_subnet"></a> [subnet](#module\_subnet) | ./subnet | n/a |
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [azurerm_route.aks_route](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/route) | resource |
+| [azurerm_route.non_inline_route](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/route) | resource |
+| [azurerm_route_table.aks_route_table](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/route_table) | resource |
+| [azurerm_route_table.route_table](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/route_table) | resource |
+| [azurerm_subnet_route_table_association.aks](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/subnet_route_table_association) | resource |
+| [azurerm_subnet_route_table_association.association](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/subnet_route_table_association) | resource |
+| [azurerm_virtual_network.vnet](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/virtual_network) | resource |
+| [azurerm_virtual_network_peering.peer](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/virtual_network_peering) | resource |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_address_space"></a> [address\_space](#input\_address\_space) | CIDRs for virtual network | `list(string)` | n/a | yes |
+| <a name="input_aks_subnets"></a> [aks\_subnets](#input\_aks\_subnets) | AKS subnets | <pre>map(object({<br/>    subnet_info = any<br/>    route_table = object({<br/>      bgp_route_propagation_enabled = bool<br/>      routes                        = map(map(string))<br/>      # keys are route names, value map is route properties (address_prefix, next_hop_type, next_hop_in_ip_address)<br/>      # https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/route_table#route<br/>    })<br/>  }))</pre> | `null` | no |
+| <a name="input_dns_servers"></a> [dns\_servers](#input\_dns\_servers) | If applicable, a list of custom DNS servers to use inside your virtual network.  Unset will use default Azure-provided resolver | `list(string)` | `null` | no |
+| <a name="input_enforce_subnet_names"></a> [enforce\_subnet\_names](#input\_enforce\_subnet\_names) | enforce subnet names based on naming\_rules variable | `bool` | `true` | no |
+| <a name="input_environment"></a> [environment](#input\_environment) | Environment blue, green, ctest etc | `string` | `""` | no |
+| <a name="input_location"></a> [location](#input\_location) | Azure Region | `string` | n/a | yes |
+| <a name="input_names"></a> [names](#input\_names) | Names to be applied to resources | `map(string)` | n/a | yes |
+| <a name="input_naming_rules"></a> [naming\_rules](#input\_naming\_rules) | naming conventions yaml file | `string` | `""` | no |
+| <a name="input_peer_defaults"></a> [peer\_defaults](#input\_peer\_defaults) | Maps of peer arguments. | <pre>object({<br/>    id                           = string<br/>    allow_virtual_network_access = bool<br/>    allow_forwarded_traffic      = bool<br/>    allow_gateway_transit        = bool<br/>    use_remote_gateways          = bool<br/>  })</pre> | <pre>{<br/>  "allow_forwarded_traffic": false,<br/>  "allow_gateway_transit": false,<br/>  "allow_virtual_network_access": true,<br/>  "id": null,<br/>  "use_remote_gateways": false<br/>}</pre> | no |
+| <a name="input_peers"></a> [peers](#input\_peers) | Peer virtual networks.  Keys are names, allowed values are same as for peer\_defaults. Id value is required. | `any` | `{}` | no |
+| <a name="input_resource_group_name"></a> [resource\_group\_name](#input\_resource\_group\_name) | Resource group name | `string` | n/a | yes |
+| <a name="input_route_tables"></a> [route\_tables](#input\_route\_tables) | Maps of route tables | <pre>map(object({<br/>    bgp_route_propagation_enabled = bool<br/>    use_inline_routes             = bool # Setting to true will revert any external route additions.<br/>    routes                        = map(map(string))<br/>    # keys are route names, value map is route properties (address_prefix, next_hop_type, next_hop_in_ip_address)<br/>    # https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/route_table#route<br/>  }))</pre> | `{}` | no |
+| <a name="input_subnet_defaults"></a> [subnet\_defaults](#input\_subnet\_defaults) | Maps of CIDRs, policies, endpoints and delegations | <pre>object({<br/>    cidrs                                         = list(string)<br/>    private_endpoint_network_policies             = string<br/>    private_link_service_network_policies_enabled = bool<br/>    service_endpoints                             = list(string)<br/>    delegations = map(object({<br/>      name    = string<br/>      actions = list(string)<br/>    }))<br/>    create_network_security_group = bool # create/associate network security group with subnet<br/>    configure_nsg_rules           = bool # deny ingress/egress traffic and configure nsg rules based on below parameters<br/>    allow_internet_outbound       = bool # allow outbound traffic to internet (configure_nsg_rules must be set to true)<br/>    allow_lb_inbound              = bool # allow inbound traffic from Azure Load Balancer (configure_nsg_rules must be set to true)<br/>    allow_vnet_inbound            = bool # allow all inbound from virtual network (configure_nsg_rules must be set to true)<br/>    allow_vnet_outbound           = bool # allow all outbound from virtual network (configure_nsg_rules must be set to true)<br/>    route_table_association       = string<br/>  })</pre> | <pre>{<br/>  "allow_internet_outbound": false,<br/>  "allow_lb_inbound": false,<br/>  "allow_vnet_inbound": false,<br/>  "allow_vnet_outbound": false,<br/>  "cidrs": [],<br/>  "configure_nsg_rules": true,<br/>  "create_network_security_group": true,<br/>  "delegations": {},<br/>  "private_endpoint_network_policies": "Disabled",<br/>  "private_link_service_network_policies_enabled": true,<br/>  "route_table_association": null,<br/>  "service_endpoints": []<br/>}</pre> | no |
+| <a name="input_subnets"></a> [subnets](#input\_subnets) | Map of subnets. Keys are subnet names, Allowed values are the same as for subnet\_defaults | `any` | `{}` | no |
+| <a name="input_tags"></a> [tags](#input\_tags) | Tags to be applied to resources | `map(string)` | n/a | yes |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| <a name="output_aks"></a> [aks](#output\_aks) | Virtual network information matching AKS module input. |
+| <a name="output_route_tables"></a> [route\_tables](#output\_route\_tables) | Maps of custom route tables. |
+| <a name="output_subnet"></a> [subnet](#output\_subnet) | Map of subnet data objects. |
+| <a name="output_subnet_nsg_ids"></a> [subnet\_nsg\_ids](#output\_subnet\_nsg\_ids) | Map of subnet ids to associated network\_security\_group ids. |
+| <a name="output_subnet_nsg_names"></a> [subnet\_nsg\_names](#output\_subnet\_nsg\_names) | Map of subnet names to associated network\_security\_group names. |
+| <a name="output_subnets"></a> [subnets](#output\_subnets) | Maps of subnet info. |
+| <a name="output_vnet"></a> [vnet](#output\_vnet) | Virtual network data object. |
+<!-- END_TF_DOCS -->

--- a/locals.tf
+++ b/locals.tf
@@ -33,4 +33,5 @@ locals {
     }
   ]...)
 
+  environment_safe  = lower(join("-", var.environment == "" ? [] : [var.environment]))
 }

--- a/main.tf
+++ b/main.tf
@@ -1,5 +1,5 @@
 resource "azurerm_virtual_network" "vnet" {
-  name                = "${var.names.product_group}-${var.names.subscription_type}-${var.names.location}-vnet"
+  name                = "${var.names.product_group}-${var.names.subscription_type}-${var.names.location}-vnet${local.environment_safe}"
   location            = var.location
   resource_group_name = var.resource_group_name
   address_space       = var.address_space

--- a/subnet/README.md
+++ b/subnet/README.md
@@ -57,3 +57,67 @@ For a full list of details provided in the output please view:<br />
 - Subnet - https://www.terraform.io/docs/providers/azurerm/r/subnet.html<br />
 - Network Security Group - https://www.terraform.io/docs/providers/azurerm/r/network_security_group.html<br />
 <br />
+
+<!-- BEGIN_TF_DOCS -->
+## Requirements
+
+No requirements.
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | n/a |
+
+## Modules
+
+No modules.
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [azurerm_network_security_group.nsg](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/network_security_group) | resource |
+| [azurerm_network_security_rule.allow_internet_outbound](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/network_security_rule) | resource |
+| [azurerm_network_security_rule.allow_lb_inbound](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/network_security_rule) | resource |
+| [azurerm_network_security_rule.allow_vnet_inbound](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/network_security_rule) | resource |
+| [azurerm_network_security_rule.allow_vnet_outbound](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/network_security_rule) | resource |
+| [azurerm_network_security_rule.deny_all_inbound](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/network_security_rule) | resource |
+| [azurerm_network_security_rule.deny_all_outbound](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/network_security_rule) | resource |
+| [azurerm_subnet.subnet](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/subnet) | resource |
+| [azurerm_subnet_network_security_group_association.subnet_nsg](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/subnet_network_security_group_association) | resource |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_allow_internet_outbound"></a> [allow\_internet\_outbound](#input\_allow\_internet\_outbound) | allow outbound traffic to internet | `bool` | `false` | no |
+| <a name="input_allow_lb_inbound"></a> [allow\_lb\_inbound](#input\_allow\_lb\_inbound) | allow inbound traffic from Azure Load Balancer | `bool` | `false` | no |
+| <a name="input_allow_vnet_inbound"></a> [allow\_vnet\_inbound](#input\_allow\_vnet\_inbound) | allow all inbound from virtual network | `bool` | `false` | no |
+| <a name="input_allow_vnet_outbound"></a> [allow\_vnet\_outbound](#input\_allow\_vnet\_outbound) | allow all outbound from virtual network | `bool` | `false` | no |
+| <a name="input_cidrs"></a> [cidrs](#input\_cidrs) | CIDRs for subnet | `list(string)` | n/a | yes |
+| <a name="input_configure_nsg_rules"></a> [configure\_nsg\_rules](#input\_configure\_nsg\_rules) | Configure network security group rules | `bool` | `false` | no |
+| <a name="input_create_network_security_group"></a> [create\_network\_security\_group](#input\_create\_network\_security\_group) | Create/associate network security group | `bool` | `true` | no |
+| <a name="input_delegations"></a> [delegations](#input\_delegations) | delegation blocks for services | <pre>map(object({<br/>    name    = string<br/>    actions = list(string)<br/>  }))</pre> | `{}` | no |
+| <a name="input_enforce_subnet_names"></a> [enforce\_subnet\_names](#input\_enforce\_subnet\_names) | enforce subnet naming rules | `bool` | `false` | no |
+| <a name="input_location"></a> [location](#input\_location) | Azure Region | `string` | n/a | yes |
+| <a name="input_names"></a> [names](#input\_names) | names to be applied to resources | `map(string)` | n/a | yes |
+| <a name="input_naming_rules"></a> [naming\_rules](#input\_naming\_rules) | naming conventions yaml file | `string` | `""` | no |
+| <a name="input_private_endpoint_network_policies"></a> [private\_endpoint\_network\_policies](#input\_private\_endpoint\_network\_policies) | Enable or Disable network policies for the private endpoint on the subnet. Setting this to true will Enable the policy and setting this to false will Disable the policy. | `string` | `"Disabled"` | no |
+| <a name="input_private_link_service_network_policies_enabled"></a> [private\_link\_service\_network\_policies\_enabled](#input\_private\_link\_service\_network\_policies\_enabled) | Enable or Disable network policies for the private link service on the subnet. Setting this to true will Enable the policy and setting this to false will Disable the policy. | `bool` | `true` | no |
+| <a name="input_resource_group_name"></a> [resource\_group\_name](#input\_resource\_group\_name) | Resource group name | `string` | n/a | yes |
+| <a name="input_service_endpoints"></a> [service\_endpoints](#input\_service\_endpoints) | service endpoints to associate with the subnet | `list(string)` | `[]` | no |
+| <a name="input_subnet_type"></a> [subnet\_type](#input\_subnet\_type) | subnet type | `string` | n/a | yes |
+| <a name="input_tags"></a> [tags](#input\_tags) | tags to be applied to resources | `map(string)` | n/a | yes |
+| <a name="input_virtual_network_name"></a> [virtual\_network\_name](#input\_virtual\_network\_name) | virtual network name | `string` | n/a | yes |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| <a name="output_id"></a> [id](#output\_id) | subnet id |
+| <a name="output_name"></a> [name](#output\_name) | subnet name |
+| <a name="output_network_security_group_id"></a> [network\_security\_group\_id](#output\_network\_security\_group\_id) | network security group id |
+| <a name="output_network_security_group_name"></a> [network\_security\_group\_name](#output\_network\_security\_group\_name) | network security group name |
+| <a name="output_subnet"></a> [subnet](#output\_subnet) | subnet data object |
+<!-- END_TF_DOCS -->

--- a/variables.tf
+++ b/variables.tf
@@ -142,3 +142,9 @@ variable "peer_defaults" {
     use_remote_gateways          = false # https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/virtual_network_peering#use_remote_gateways
   }
 }
+
+variable "environment" {
+  description = "Environment blue, green, ctest etc"
+  type        = string
+  default     = ""
+}


### PR DESCRIPTION
Currently the naming of vnet is supported only for one VNET per subscription . But we have more than 1 VNET per subscription. So we should be able to add a suffix to distinguish between them.

Dirrk/terraform-docs  action was archived so replaced it with the other recommended action.