### PR TITLE
fix: eliminate race condition when creating subnets and peering

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -139,6 +139,12 @@ resource "azurerm_subnet_route_table_association" "aks" {
 }
 
 resource "azurerm_virtual_network_peering" "peer" {
+  # Set explicit dependency on resources that need the subnet to be in a Succeeded state
+  # before peering can be established, to avoid a ReferencedResourceNotProvisioned error.
+  depends_on = [
+    azurerm_subnet_route_table_association.association,
+    azurerm_subnet_route_table_association.aks,
+  ]
   for_each = local.peers
 
   name                         = each.key


### PR DESCRIPTION
Closes #79. 

Tells the Vnet peering resource to depend on route table associations with the subnets.

Subnets must be in a succeeded state to attach route tables to them, so depending on the route table associations guarantees that Terraform attempts to create the peering connection only after the subnets have been created successfully.

Tested to the best of my ability. The race condition doesn't occur all the time, but I ran the updated code several times (apply -> destroy -> apply -> destroy -> ...) and never saw the error again, so hopefully this fixes it.